### PR TITLE
Update README.md

### DIFF
--- a/session-3-jshell/README.md
+++ b/session-3-jshell/README.md
@@ -95,7 +95,7 @@ Now try some more REPL commands, at the `jshell` prompt:
 As mentioned earlier, Java 9 provides a JShell API that we can access from within our application:
 
 ```java
-    JShell shell = JSheel.create();
+    JShell shell = JShell.create();
     shell.eval("int x = 5;");
     Stream<VarSnippet> vars = shell.variables();
 ```


### PR DESCRIPTION
Class name mistake rectified (Typological error), JSheel corrected to JShell.